### PR TITLE
fix(api-url): Static build accept API host as variable 🚀

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 
 RUN npm install
 RUN npm install -g serve
+RUN npm run build
 RUN chmod +x command.sh
 
 ENTRYPOINT [ "/app/command.sh" ]

--- a/ui/command.sh
+++ b/ui/command.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 cd /app
-npm run build
+echo "globalThis.VUE_APP_IONE_API_BASE_URL = '"$VUE_APP_IONE_API_BASE_URL"';" > ./dist/config.js
 serve -s dist

--- a/ui/package.json
+++ b/ui/package.json
@@ -59,7 +59,10 @@
           "jest": true
         }
       }
-    ]
+    ],
+    "globals": {
+      "VUE_APP_IONE_API_BASE_URL": true
+    }
   },
   "browserslist": [
     "> 1%",

--- a/ui/public/config.js
+++ b/ui/public/config.js
@@ -1,0 +1,1 @@
+globalThis.VUE_APP_IONE_API_BASE_URL = '';

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -16,6 +16,7 @@
   </noscript>
   <div id="app"></div>
   <!-- built files will be auto injected -->
+  <script src="./config.js"></script>
 </body>
 
 </html>

--- a/ui/src/components/log/loader.vue
+++ b/ui/src/components/log/loader.vue
@@ -37,7 +37,7 @@ export default {
     load() {
       let vm = this;
       let ws = new WebSocket(
-        `${process.env.VUE_APP_IONE_API_BASE_URL.replace(
+        `${VUE_APP_IONE_API_BASE_URL.replace(
           "https",
           "wss"
         )}/wss/ione/log/${this.log.key}?ws=true&auth=${btoa(

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -4,9 +4,9 @@ import store from "@/store";
 import router from "@/router";
 import axios from "axios";
 
-console.log(`Using '${process.env.VUE_APP_IONE_API_BASE_URL}' as base URL`);
+console.log(`Using '${VUE_APP_IONE_API_BASE_URL}' as base URL`);
 Vue.prototype.$axios = axios.create({
-  baseURL: `${process.env.VUE_APP_IONE_API_BASE_URL}`,
+  baseURL: `${VUE_APP_IONE_API_BASE_URL}`,
 });
 
 Vue.config.productionTip = false;

--- a/ui/src/store/index.js
+++ b/ui/src/store/index.js
@@ -35,7 +35,7 @@ export default new Vuex.Store({
       let pool = (
         await axios({
           method: "post",
-          url: process.env.VUE_APP_IONE_API_BASE_URL + "/one.u.pool.to_hash!",
+          url: VUE_APP_IONE_API_BASE_URL + "/one.u.pool.to_hash!",
           auth: state.credentials,
           data: {},
         })
@@ -53,7 +53,7 @@ export default new Vuex.Store({
       let pool = (
         await axios({
           method: "post",
-          url: process.env.VUE_APP_IONE_API_BASE_URL + "/one.g.pool.to_hash!",
+          url: VUE_APP_IONE_API_BASE_URL + "/one.g.pool.to_hash!",
           auth: state.credentials,
           data: {},
         })

--- a/ui/src/views/Login.vue
+++ b/ui/src/views/Login.vue
@@ -46,7 +46,7 @@ export default {
         password: "",
       },
       fails: 0,
-      endpoint: process.env.VUE_APP_IONE_API_BASE_URL,
+      endpoint: VUE_APP_IONE_API_BASE_URL,
     };
   },
   methods: {


### PR DESCRIPTION
#### Now it is enough to set the url when running the container in ```VUE_APP_IONE_API_BASE_URL``` variable 

```bash 
$ cd ./ui
$ docker build --tag ione .
$ docker run --rm -p 5000:5000 --name ione-admin -d -e VUE_APP_IONE_API_BASE_URL='https://testing.example.com' ione
```